### PR TITLE
fix: add team members to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Systems Development and Frameworks - Group Assignments - Winter Term 2019/20
+
+| Github Alias                                         | Name         |
+| ---------------------------------------------------- | ------------ |
+| [@your](https://github.com/your)                     | Alice A.     |
+| [@github-account](https://github.com/github-account) | Bob B.       |
+| [@goes-here](https://github.com/goes-here)           | Mallory M.   |


### PR DESCRIPTION
Apparently you cannot see the collaborators list on a repository, only
the list of *contributors*. So if your team mates never committed to the
repository then I can't see who is a collaborator and I have troubles to
assign your fork to the list of participants of the course "Systems
Development and Frameworks".

Credit goes to @medizinmensch and his team members:
https://github.com/medizinmensch/Systems-Development-and-Frameworks/
I really like their idea of adding a hint to the README.md to tell who
is a collaborator.

**Please change the table and add a shortened version of your own
names!**